### PR TITLE
Added version code for Android

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,8 @@
       "buildNumber": "4"
     },
     "android": {
-      "package": "edu.utdallas.jonsson.connect"
+      "package": "edu.utdallas.jonsson.connect",
+      "versionCode": 4
     },
     "description": "The Jonsson Connect App will connect students, alumni, and potential employers with each other and with the Erik Jonsson School of Engineering and Computer Science (ECS). The app will inform its users of the latest news, jobs, and events tied to the Jonsson School. Although a UT Dallas application is available on Google’s Playstore and Apple’s Appstore, no such application exists specifically for the Erik Jonsson School. We plan to complete development of the Jonsson Connect app by November 19th and we plan to have this app available in the Android and Apple app stores by December 3rd, 2018. The app is currently in Phase 2 of its development.",
     "githubUrl": "https://github.com/MSAT7/jonsson"


### PR DESCRIPTION
Without the version code identified, Expo will always build the APK using version code 1. The version code must always be incremented when updating the APK on the Google Play Store.